### PR TITLE
fixed map_predict_label() 

### DIFF
--- a/notebooks/neural_networks/logistic_regression.ipynb
+++ b/notebooks/neural_networks/logistic_regression.ipynb
@@ -195,7 +195,7 @@
    "outputs": [],
    "source": [
     "def map_predict_label(l):\n",
-    "    return np.array(l).argmax()\n",
+    "    return l.argmax()\n",
     "def map_groundtruth_label(l):\n",
     "    return l[0] - 1"
    ]


### PR DESCRIPTION
the input to map_predict_label is already a numpy array. Therefore you can just call l.argmax() directly.