### PR TITLE
Fix reference to visualization notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Step-by-step Deep Learning Tutorials on Apache Spark using [BigDL](https://githu
 12. [LSTM](https://github.com/intel-analytics/BigDL-Tutorials/blob/master/notebooks/neural_networks/lstm.ipynb)
 13. [Bi-directional RNN](https://github.com/intel-analytics/BigDL-Tutorials/blob/master/notebooks/neural_networks/birnn.ipynb)
 14. [Auto-encoder](https://github.com/intel-analytics/BigDL-Tutorials/blob/master/notebooks/neural_networks/autoencoder.ipynb)
-15. [Visualizing Learning](https://github.com/intel-analytics/BigDL-Tutorials/blob/master/notebooks/neural_networks/visualization.ipynb)
+15. [Visualizing Learning](https://github.com/vincenzosantopietro/BigDL-Tutorials/blob/master/notebooks/bigdl_features/visualization.ipynb)
 
 ### Environment
 + Python 3.5/3.6


### PR DESCRIPTION
I've fixed the reference link to the visualization notebook since it was broken. 

I assumed the notebook is in the right place and the link had to be changed. 
If the link is right and the notebook is in the wrong place, feel free to reject this PR.